### PR TITLE
Implemented Extension B: ViewSchedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a project template for a greenfield Java project. It's named after the J
 
 Prerequisites: JDK 11, update Intellij to the most recent version.
 
-1. Open Intellij (if you are not in the welcome screen, click `duke.Storage` > `Close Project` to close the existing project first)
+1. Open Intellij (if you are not in the welcome screen, click `duke.storage.Storage` > `Close Project` to close the existing project first)
 1. Open the project into Intellij as follows:
    1. Click `Open`.
    1. Select the project directory, and click `OK`.

--- a/src/data/duke.txt
+++ b/src/data/duke.txt
@@ -11,3 +11,4 @@ E | 0 | hm | 2022-02-02 | 2022-02-02
 E | 0 | valentine's day | 2023-02-14 | 2023-02-14
 T | 0 | aaaa veryyyy longggg taskkk to doooo aiyooo so many things to doo
 T | 0 | vday
+D | 0 | iP | 2022-02-14

--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -1,6 +1,9 @@
 package duke;
 import duke.command.Command;
 import duke.exception.DukeException;
+import duke.storage.Storage;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;
 import javafx.util.Duration;

--- a/src/main/java/duke/Main.java
+++ b/src/main/java/duke/Main.java
@@ -2,6 +2,7 @@ package duke;
 
 import java.io.IOException;
 
+import duke.ui.MainWindow;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -13,6 +13,7 @@ import duke.command.ListCommand;
 import duke.command.MarkCommand;
 import duke.command.ToDoCommand;
 import duke.command.UnmarkCommand;
+import duke.command.ViewCommand;
 import duke.exception.DukeException;
 import duke.task.Deadline;
 import duke.task.Event;
@@ -34,6 +35,7 @@ public class Parser {
         String[] commandDetails = userInput.trim().split(" ", 2);
         String commandType = commandDetails[0];
 
+        trimArgs(commandDetails);
         checkSufficientArgs(commandType, commandDetails);
         String arguments = commandDetails.length < 2 ? "" : commandDetails[1];
 
@@ -50,6 +52,8 @@ public class Parser {
              return new DeleteCommand(parseIntArg(arguments));
         case "find":
             return new FindCommand(arguments);
+        case "view":
+            return new ViewCommand(parseDate(arguments));
         case "todo":
             Todo todo = new Todo(parseTodo(arguments));
             return new ToDoCommand(todo);
@@ -90,6 +94,11 @@ public class Parser {
     public void trimArgs(String[] arguments) {
         for (int i = 0; i < arguments.length; i++) {
             arguments[i] = arguments[i].trim();
+            if (arguments[i].isEmpty()) {
+                arguments[i] = null;
+            } else {
+                continue;
+            }
         }
     }
 
@@ -106,6 +115,15 @@ public class Parser {
             return intArgument - 1;
         } catch (NumberFormatException e) {
             throw new DukeException("input type");
+        }
+    }
+
+    public LocalDate parseDate(String argument) throws DukeException {
+        try {
+            LocalDate date = LocalDate.parse(argument);
+            return date;
+        } catch (DateTimeParseException e) {
+            throw new DukeException("date format");
         }
     }
 

--- a/src/main/java/duke/command/ByeCommand.java
+++ b/src/main/java/duke/command/ByeCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 
 /**
  * The ByeCommand class encapsulates the variables and methods related to bye commands.

--- a/src/main/java/duke/command/Command.java
+++ b/src/main/java/duke/command/Command.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.exception.DukeException;
 
 

--- a/src/main/java/duke/command/DeadlineCommand.java
+++ b/src/main/java/duke/command/DeadlineCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.exception.DukeException;
 import duke.task.Deadline;
 

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.exception.DukeException;
 import duke.task.Task;
 

--- a/src/main/java/duke/command/EventCommand.java
+++ b/src/main/java/duke/command/EventCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.task.Event;
 
 /**

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -1,9 +1,8 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.exception.DukeException;
-
 
 /**
  * The FindCommand class encapsulates the variables and methods related to Find commands.

--- a/src/main/java/duke/command/ListCommand.java
+++ b/src/main/java/duke/command/ListCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 
 /**
  * The ListCommand class encapsulates the variables and methods related to List commands.

--- a/src/main/java/duke/command/MarkCommand.java
+++ b/src/main/java/duke/command/MarkCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.exception.DukeException;
 
 

--- a/src/main/java/duke/command/ToDoCommand.java
+++ b/src/main/java/duke/command/ToDoCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.exception.DukeException;
 import duke.task.Todo;
 

--- a/src/main/java/duke/command/UnmarkCommand.java
+++ b/src/main/java/duke/command/UnmarkCommand.java
@@ -1,7 +1,7 @@
 package duke.command;
 
-import duke.TaskList;
-import duke.Ui;
+import duke.storage.TaskList;
+import duke.ui.Ui;
 import duke.exception.DukeException;
 
 /**

--- a/src/main/java/duke/command/ViewCommand.java
+++ b/src/main/java/duke/command/ViewCommand.java
@@ -1,0 +1,21 @@
+package duke.command;
+
+import java.time.LocalDate;
+
+import duke.storage.TaskList;
+import duke.ui.Ui;
+
+public class ViewCommand extends Command {
+    private static final String FIND_COMMAND = "find";
+    private LocalDate date;
+
+    public ViewCommand(LocalDate date) {
+        super(FIND_COMMAND);
+        this.date = date;
+    }
+
+    @Override
+    public String execute(TaskList taskList, Ui ui) {
+        return ui.showSchedule(taskList, this.date);
+    }
+}

--- a/src/main/java/duke/exception/DukeException.java
+++ b/src/main/java/duke/exception/DukeException.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 /** Class contains all exceptions thrown by Duke. */
 public class DukeException extends Exception {
     protected ArrayList<String> commandError = new ArrayList<>(
-            Arrays.asList("todo", "deadline", "event", "missing details"));
+            Arrays.asList("todo", "deadline", "event", "view", "missing details"));
     protected ArrayList<String> indexError = new ArrayList<>(
             Arrays.asList("mark", "unmark", "delete"));
     protected ArrayList<String> fileError = new ArrayList<>(
@@ -14,7 +14,7 @@ public class DukeException extends Exception {
                     "updating file", "saving changes to file", "file not found", "empty line in file"));
     protected ArrayList<String> formatError = new ArrayList<>(
             Arrays.asList("date format", "wrong order"));
-    protected ArrayList<String> findError = new ArrayList<>(Arrays.asList("empty keyword"));
+    protected ArrayList<String> findError = new ArrayList<>(Arrays.asList("find", "empty keyword"));
     protected String errorMsg;
 
     /**
@@ -23,7 +23,7 @@ public class DukeException extends Exception {
      */
     public DukeException(String command) {
         if (commandError.contains(command)) {
-            this.errorMsg = "The " + command + " description cannot be empty.";
+            this.errorMsg = "The " + command + " description/date cannot be empty.";
         } else if (indexError.contains(command)) {
             this.errorMsg = "Please remember to enter an index!";
         } else if (fileError.contains(command)) {

--- a/src/main/java/duke/storage/Storage.java
+++ b/src/main/java/duke/storage/Storage.java
@@ -1,4 +1,4 @@
-package duke;
+package duke.storage;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/main/java/duke/storage/TaskList.java
+++ b/src/main/java/duke/storage/TaskList.java
@@ -1,5 +1,6 @@
-package duke;
+package duke.storage;
 
+import java.time.LocalDate;
 import java.util.LinkedList;
 
 import duke.exception.DukeException;
@@ -154,6 +155,18 @@ public class TaskList {
             throw new DukeException("missing details");
         }
         this.lst.add(task);
+    }
+
+    public String printSchedule(LocalDate date) {
+        int count = 1;
+        String schedule = "";
+        for (int i = 0; i < this.getSize(); i++) {
+            Task task = this.lst.get(i);
+            if (task.isTaskInSchedule(date)) {
+                schedule += String.format("%d. %s\n", count, task);
+            }
+        }
+        return schedule;
     }
 
     /**

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -23,6 +23,11 @@ public class Deadline extends Task {
     }
 
     @Override
+    public boolean isTaskInSchedule(LocalDate date) {
+        return this.deadline.equals(date);
+    }
+
+    @Override
     public String toFile() {
         return String.format("D | %s | %s\n", super.toFile(), deadline);
     }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -30,6 +30,13 @@ public class Event extends Task {
         return String.format("E | %s | %s | %s\n", super.toFile(), this.start, this.end);
     }
 
+    @Override
+    public boolean isTaskInSchedule(LocalDate date) {
+        boolean checkStart = this.start.compareTo(date) <= 0;
+        boolean checkEnd = this.end.compareTo(date) >= 0;
+        return checkStart && checkEnd;
+    }
+
     /**
      * Creates Event task from string from file.
      * @param taskNameData String containing taskName from file.

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -1,5 +1,7 @@
 package duke.task;
 
+import java.time.LocalDate;
+
 /**
  * Abstract class contains variables and methods related to Tasks.
  */
@@ -33,6 +35,13 @@ public abstract class Task {
     public String getTaskName() {
         return this.taskName;
     }
+
+    /**
+     * Checks whether task falls on the given date.
+     * @param date Date to be checked against.
+     * @return true if task falls on the date and false otherwise.
+     */
+    public abstract boolean isTaskInSchedule(LocalDate date);
 
     /**
      * Marks task as done or undone depending on status.

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -2,6 +2,8 @@ package duke.task;
 
 import duke.exception.DukeException;
 
+import java.time.LocalDate;
+
 /**
  * Class contains variables and methods related to Todo task.
  */
@@ -13,6 +15,11 @@ public class Todo extends Task {
     @Override
     public String toFile() {
         return String.format("T | %s\n", super.toFile());
+    }
+
+    @Override
+    public boolean isTaskInSchedule(LocalDate date) {
+        return false;
     }
 
     /**

--- a/src/main/java/duke/ui/DialogBox.java
+++ b/src/main/java/duke/ui/DialogBox.java
@@ -1,4 +1,4 @@
-package duke;
+package duke.ui;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/main/java/duke/ui/Launcher.java
+++ b/src/main/java/duke/ui/Launcher.java
@@ -1,5 +1,6 @@
-package duke;
+package duke.ui;
 
+import duke.Main;
 import javafx.application.Application;
 
 /**

--- a/src/main/java/duke/ui/MainWindow.java
+++ b/src/main/java/duke/ui/MainWindow.java
@@ -1,5 +1,7 @@
-package duke;
+package duke.ui;
 
+import duke.Duke;
+import duke.ui.DialogBox;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.ScrollPane;

--- a/src/main/java/duke/ui/Ui.java
+++ b/src/main/java/duke/ui/Ui.java
@@ -1,7 +1,10 @@
-package duke;
+package duke.ui;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Scanner;
 
+import duke.storage.TaskList;
 import duke.task.Deadline;
 import duke.task.Event;
 import duke.task.Task;
@@ -48,11 +51,11 @@ public class Ui {
 
     /**
      * Prints TaskList of Duke.
-     * @param lst TaskList to be printed.
+     * @param taskList TaskList to be printed.
      * @return Response after printing lst.
      */
-    public String showList(TaskList lst) {
-        return showLine() + "Here are the tasks in your list:\n" + lst.printList() + showLine();
+    public String showList(TaskList taskList) {
+        return showLine() + "Here are the tasks in your list:\n" + taskList.printList() + showLine();
     }
 
     /**
@@ -116,5 +119,11 @@ public class Ui {
     public String showEvent(Event event, int size) {
         return showLine() + "Got it! I've added: \n" + " " + event.toString() + "\n"
                 + String.format("Now you have %d tasks in the list!\n", size) + showLine();
+    }
+
+    public String showSchedule(TaskList taskList, LocalDate date) {
+        String formattedDate = date.format(DateTimeFormatter.ofPattern("MMM d yyyy"));
+        return showLine() + "Here is your schedule for " + formattedDate + ":)\n"
+                + taskList.printSchedule(date) + showLine();
     }
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="duke.MainWindow">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="duke.ui.MainWindow">
     <children>
         <TextField fx:id="userInput" layoutY="558.0" onAction="#handleUserInput" prefHeight="41.0" prefWidth="324.0" AnchorPane.bottomAnchor="1.0">
          <font>


### PR DESCRIPTION
Users are able to add deadlines and events with specified dates

However, to view a list, users can only choose between 'list' to view every single task or 'find' which only shows tasks with matching names. Hence, adding a view schedule functionality will give the users more flexibility.

Add the supporting methods to TaskList, Task and Parser and Ui. DukeException has additional cases added to handle errors by 'view'.

This gives the users more flexibility in using their list by supporting the need to view their schedules for a specific date.